### PR TITLE
Add a configurable id formatter 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.expedia.www</groupId>
   <artifactId>spring-cloud-sleuth-haystack-reporter</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Spring Cloud Sleuth Haystack Reporter</name>

--- a/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/configuration/HaystackReporterAutoConfiguration.java
+++ b/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/configuration/HaystackReporterAutoConfiguration.java
@@ -22,6 +22,9 @@ import com.expedia.www.haystack.client.metrics.micrometer.MicrometerMetricsRegis
 import com.expedia.www.haystack.remote.clients.Client;
 import com.expedia.www.haystack.remote.clients.GRPCAgentProtoClient;
 import com.expedia.www.haystack.remote.clients.HttpCollectorProtoClient;
+import com.expedia.www.spring.cloud.sleuth.haystack.reporter.idextractors.IdExtractor;
+import com.expedia.www.spring.cloud.sleuth.haystack.reporter.idextractors.StringIdExtractor;
+import com.expedia.www.spring.cloud.sleuth.haystack.reporter.idextractors.UUIDIdExtractor;
 import com.expedia.www.spring.cloud.sleuth.haystack.reporter.reporters.HaystackReporter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.HashMap;
@@ -58,8 +61,8 @@ public class HaystackReporterAutoConfiguration {
     }
 
     @Bean
-    public HaystackReporter spanReporter(String serviceName, List<Client> clients) {
-        return new HaystackReporter(serviceName, clients);
+    public HaystackReporter spanReporter(String serviceName, List<Client> clients, IdExtractor idExtractor) {
+        return new HaystackReporter(serviceName, clients, idExtractor);
     }
 
     @Bean
@@ -85,6 +88,16 @@ public class HaystackReporterAutoConfiguration {
         }
 
         return clients;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public IdExtractor idExtractor(HaystackSettings settings) {
+        if (settings.getIdFormat().equalsIgnoreCase("UUID")) {
+            return new UUIDIdExtractor();
+        } else {
+            return new StringIdExtractor();
+        }
     }
 
     @Bean

--- a/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/configuration/HaystackSettings.java
+++ b/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/configuration/HaystackSettings.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("spring.sleuth.haystack")
 public class HaystackSettings {
     private boolean enabled = true;
-    private String idFormat = "UUID";
+    private String idFormat = "string";
 
     private ClientConfiguration client = new ClientConfiguration();
 

--- a/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/configuration/HaystackSettings.java
+++ b/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/configuration/HaystackSettings.java
@@ -26,6 +26,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("spring.sleuth.haystack")
 public class HaystackSettings {
     private boolean enabled = true;
+    private String idFormat = "UUID";
+
     private ClientConfiguration client = new ClientConfiguration();
 
     public ClientConfiguration getClient() {
@@ -42,6 +44,14 @@ public class HaystackSettings {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public String getIdFormat() {
+        return idFormat;
+    }
+
+    public void setIdFormat(String idFormat) {
+        this.idFormat = idFormat;
     }
     
     public static class ClientConfiguration {

--- a/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/IdExtractor.java
+++ b/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/IdExtractor.java
@@ -1,0 +1,11 @@
+package com.expedia.www.spring.cloud.sleuth.haystack.reporter.idextractors;
+
+import zipkin2.Span;
+
+public interface IdExtractor {
+    Object getTraceId(Span span);
+
+    Object getSpanId(Span span);
+
+    Object getParentSpanId(Span span);
+}

--- a/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/StringIdExtractor.java
+++ b/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/StringIdExtractor.java
@@ -16,6 +16,9 @@ public class StringIdExtractor implements IdExtractor {
 
     @Override
     public String getParentSpanId(Span span) {
+        if (span.parentId() == null) {
+            return "";
+        }
         return span.parentId();
     }
 }

--- a/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/StringIdExtractor.java
+++ b/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/StringIdExtractor.java
@@ -1,0 +1,21 @@
+package com.expedia.www.spring.cloud.sleuth.haystack.reporter.idextractors;
+
+import zipkin2.Span;
+
+public class StringIdExtractor implements IdExtractor {
+
+    @Override
+    public String getTraceId(Span span) {
+        return span.traceId();
+    }
+
+    @Override
+    public String getSpanId(Span span) {
+        return span.id();
+    }
+
+    @Override
+    public String getParentSpanId(Span span) {
+        return span.parentId();
+    }
+}

--- a/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/UUIDIdExtractor.java
+++ b/src/main/java/com/expedia/www/spring/cloud/sleuth/haystack/reporter/idextractors/UUIDIdExtractor.java
@@ -1,0 +1,31 @@
+package com.expedia.www.spring.cloud.sleuth.haystack.reporter.idextractors;
+
+import brave.internal.HexCodec;
+import zipkin2.Span;
+
+import java.util.UUID;
+
+public class UUIDIdExtractor implements IdExtractor {
+
+    @Override
+    public String getTraceId(Span span) {
+        final Long lowTraceId = HexCodec.lowerHexToUnsignedLong(span.traceId());
+        final Long highTraceId = span.traceId().length() == 32 ? HexCodec.lowerHexToUnsignedLong(span.traceId(), 0) : 0;
+
+        final UUID traceId = new UUID(highTraceId, lowTraceId);
+        return traceId.toString();
+    }
+
+    @Override
+    public String getSpanId(Span span) {
+        return new UUID(0, HexCodec.lowerHexToUnsignedLong(span.id())).toString();
+    }
+
+    @Override
+    public String getParentSpanId(Span span) {
+        if (span.parentId() == null) {
+            return "";
+        }
+        return new UUID(0, HexCodec.lowerHexToUnsignedLong(span.parentId())).toString();
+    }
+}


### PR DESCRIPTION
* Id format is to be passed as configuration to sleuth application: 
     ** spring.sleuth.haystack.idformat: string
     ** spring.sleuth.haystack.idformat: UUID
default is string format => All ids span, trace, parent span, etc, would be passed as is received in the Zipkin span.